### PR TITLE
Fix configuration for the better_whitespace plugin

### DIFF
--- a/lua/user/autocommands.lua
+++ b/lua/user/autocommands.lua
@@ -18,11 +18,6 @@ vim.api.nvim_create_autocmd("FileType", {
 local M = {}
 
 M.config = function()
-  vim.api.nvim_create_autocmd("FileType", {
-    pattern = "markdown",
-    -- do not automatically strip whitespace from markdown files
-    command = ":DisableStripWhitespaceOnSave",
-  })
 
 end
 

--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -84,7 +84,12 @@ M.config = function()
     },
     { "rodjek/vim-puppet" },
     { "godlygeek/tabular" },
-    { "ntpeters/vim-better-whitespace" },
+    {
+      "ntpeters/vim-better-whitespace",
+      setup = function()
+        require("user.plugins.better_whitespace").setup()
+      end
+    },
     { "vim-scripts/loremipsum" },
     {
       "norcalli/nvim-colorizer.lua",

--- a/lua/user/plugins/better_whitespace.lua
+++ b/lua/user/plugins/better_whitespace.lua
@@ -1,5 +1,26 @@
 -- Setup better whitespace plugin
 -- see https://github.com/ntpeters/vim-better-whitespace
 
--- The same list as the default except markown is removed to show whitepace in markdown files
-vim.g.better_whitespace_filetypes_blacklist = { 'diff', 'git', 'gitcommit', 'unite', 'qf', 'help', 'fugitive' }
+local M = {}
+
+M.setup = function()
+  -- Enable highlighting and stripping on modified lines only
+  vim.g.better_whitespace_enabled = 1
+  vim.g.strip_only_modified_lines = 1
+
+  -- The same list as the default except markown is removed to show whitepace in markdown files
+  vim.g.better_whitespace_filetypes_blacklist = { 'diff', 'git', 'gitcommit', 'unite', 'qf', 'help', 'fugitive' }
+
+  -- Autocommands for this plugins
+  local group = vim.api.nvim_create_augroup("user.plugins.better_whitespace", { clear = true })
+  vim.api.nvim_create_autocmd("FileType", {
+    pattern = "markdown",
+    -- do not automatically strip whitespace from markdown files
+    command = ":DisableStripWhitespaceOnSave",
+    group = group,
+  })
+
+
+end
+
+return M


### PR DESCRIPTION
A setup function is now responsible for setting up the plugin in terms
of global configuration parameters and autocommands. All relevant code
is now in module user.plugins.better_whitespace.
The autocommand to disable stripping whitespace for markdown is now also
moved there and wrapped in a plugin specific autocommand group.

Fixes #14
