### PR TITLE
Add toggleterm buffers to the blacklist

### DIFF
--- a/lua/user/plugins/better_whitespace.lua
+++ b/lua/user/plugins/better_whitespace.lua
@@ -9,7 +9,7 @@ M.setup = function()
   vim.g.strip_only_modified_lines = 1
 
   -- The same list as the default except markown is removed to show whitepace in markdown files
-  vim.g.better_whitespace_filetypes_blacklist = { 'diff', 'git', 'gitcommit', 'unite', 'qf', 'help', 'fugitive' }
+  vim.g.better_whitespace_filetypes_blacklist = { 'diff', 'git', 'gitcommit', 'unite', 'qf', 'help', 'fugitive', 'toggleterm' }
 
   -- Autocommands for this plugins
   local group = vim.api.nvim_create_augroup("user.plugins.better_whitespace", { clear = true })


### PR DESCRIPTION
This commit turns off trailing whitespace coloring in toggleterm buffers.

Fixes #19
